### PR TITLE
Bug fixes

### DIFF
--- a/roles/modify-connectors/tasks/main.yml
+++ b/roles/modify-connectors/tasks/main.yml
@@ -49,20 +49,20 @@
       vars:
         # properties set for key converter
         key_converter: "{{item.key_converter | default('org.apache.kafka.connect.json.JsonConverter')}}"
-        key_converter_schemas_enable: "{{item.key_converter_schemas_enable | default('false')}}"
-        key_converter_schema_registry_url: "{{((item.key_converter_schemas_enable | default('false')) == 'true') | ternary('http://' + api_addr + ':' + (schema_registry_port | string),'')}}"
+        key_converter_schemas_enable: "{{(item.key_converter_schemas_enable | default('false') | lower)}}"
+        key_converter_schema_registry_url: "{{((item.key_converter_schemas_enable | default('false') | lower) == 'true') | ternary('http://' + api_addr + ':' + (schema_registry_port | string),'')}}"
         # properties set for value converter
         value_converter: "{{item.value_converter | default('org.apache.kafka.connect.json.JsonConverter')}}"
-        value_converter_schemas_enable: "{{item.value_converter_schemas_enable | default('false')}}"
-        value_converter_schema_registry_url: "{{((item.value_converter_schemas_enable | default('false')) == 'true') | ternary('http://' + api_addr + ':' + (schema_registry_port | string),'')}}"
+        value_converter_schemas_enable: "{{item.value_converter_schemas_enable | default('false') | lower}}"
+        value_converter_schema_registry_url: "{{((item.value_converter_schemas_enable | default('false') | lower) == 'true') | ternary('http://' + api_addr + ':' + (schema_registry_port | string),'')}}"
         # properties set for internal key converter
         internal_key_converter: "{{item.internal_key_converter | default('org.apache.kafka.connect.json.JsonConverter')}}"
-        internal_key_converter_schemas_enable: "{{item.internal_key_converter_schemas_enable | default('false')}}"
-        internal_key_converter_schema_registry_url: "{{((item.internal_key_converter_schemas_enable | default('false')) == 'true') | ternary('http://' + api_addr + ':' + (schema_registry_port | string),'')}}"
+        internal_key_converter_schemas_enable: "{{item.internal_key_converter_schemas_enable | default('false') | lower}}"
+        internal_key_converter_schema_registry_url: "{{((item.internal_key_converter_schemas_enable | default('false') | lower) == 'true') | ternary('http://' + api_addr + ':' + (schema_registry_port | string),'')}}"
         # properties set for internal value converter
         internal_value_converter: "{{item.internal_value_converter | default('org.apache.kafka.connect.json.JsonConverter')}}"
-        internal_value_converter_schemas_enable: "{{item.internal_value_converter_schemas_enable | default('false')}}"
-        internal_value_converter_schema_registry_url: "{{((item.internal_value_converter_schemas_enable | default('false')) == 'true') | ternary('http://' + api_addr + ':' + (schema_registry_port | string),'')}}"
+        internal_value_converter_schemas_enable: "{{item.internal_value_converter_schemas_enable | default('false') | lower}}"
+        internal_value_converter_schema_registry_url: "{{((item.internal_value_converter_schemas_enable | default('false') | lower) == 'true') | ternary('http://' + api_addr + ':' + (schema_registry_port | string),'')}}"
         # worker specific configuration parameters
         worker_name: "{{item.name | default('')}}"
         worker_classpath: "{{item.worker_classpath | default(kafka_plugin_dir + '/' + item.name + ',' + kafka_plugin_dir)}}"

--- a/roles/modify-connectors/tasks/manage-worker.yml
+++ b/roles/modify-connectors/tasks/manage-worker.yml
@@ -55,6 +55,18 @@
       become: true
     when: kafka_topics_out.rc == 0
   when: action == 'start-workers' and worker_mode == 'Distributed'
+# if we're starting a standalone worker, then ensure that a directory
+# exists that we can use for the offset filename
+- block:
+  - name: Ensure offset file directory exists
+    file:
+      path: "{{kafka_data_dir}}/offset-files"
+      state: directory
+      owner: "{{kafka_user}}"
+      group: "{{kafka_group}}"
+      mode: 0755
+    become: true
+  when: action == 'start-workers' and worker_mode == 'Standalone'
 # if a worker is not running at the named URL and we've been asked to start
 # a connector worker, then start it
 - block:
@@ -182,7 +194,6 @@
     # start the standalone worker with the same worker properties used when it
     # was created
     - block:
-      - debug: var=connector_list
       # construct a list of connector properties files
       - name: Get list of names from the connector_list entries
         set_fact:
@@ -190,8 +201,6 @@
       - name: Construct list of corresponding connector properties filenames
         set_fact:
           connector_prop_files: "{{ connector_names | map('regex_replace', '(.*)', '/etc/kafka-connectors/\\1.properties') | list }}"
-      - debug: var=connector_prop_files
-      - debug: msg="connect-standalone -daemon /etc/kafka-connectors/{{worker_props_filename}} {{connector_prop_files | join(' ')}}"
       # and restart the daemon with the same worker properties used when it was created
       - name: Restart the daemon
         shell: "connect-standalone -daemon /etc/kafka-connectors/{{worker_props_filename}} {{connector_prop_files | join(' ')}}"

--- a/roles/modify-connectors/templates/standalone-worker.properties.j2
+++ b/roles/modify-connectors/templates/standalone-worker.properties.j2
@@ -33,4 +33,4 @@ internal.key.converter={{internal_key_converter}}
 internal.value.converter={{internal_value_converter}}
 
 # file to use to manage offsets
-offset.storage.file.filename={{kafka_data_dir}}/{{worker_offset_filename}}
+offset.storage.file.filename={{kafka_data_dir}}/offset-files/{{worker_offset_filename}}


### PR DESCRIPTION
The changes in this PR fix two recently discovered bugs in the `modify-connectors.yml` playbook, namely:

* it fixes an issue that cropped up when configuration files were used that defined any of the `*_schemas_enabled` (eg. `key_converter_schemas_enable`, `value_converter_schemas_enable`, etc.) flags using the values `true` and `false` rather than their string equivalents (`'true'` and `'false'`); in this scenario, a comparison was attempted between the value from the configuration file (which maps into the boolean value `True` or `False` when the YAML file is loaded) and the string value `'true'`; if this comparison failed then the corresponding URL was set to the empty string and not set in the worker configuration file. While this issue could be resolved by the user by surrounding these true and false values with quotes, we felt that the playbook should handle this scenario more smoothly. In this PR we have made changes to the playbook to resolve this issue by running the value from the configuration file (if a value was defined) through the `lower` Jinja2 filter, ensuring that the value we're comparing with is a string (and is either `'true'` or `'false'`, regardless of whether or not the user put quotes around the corresponding value in their configuration file)
* it resolves an issue with the directory that was used to store the offset file in standalone deployments; previous versions of the `modify-connectors.yml` playbook configured the worker to place this file in the `kafka_data_dir` (which defaults to the `/data` directory); unfortunately, this directory is typically owned by the `root` user, and the worker is started under the `{{kafka_user}}` username, so a permissions error was thrown whenever the worker attempted to store data in the offset filename. This PR modifies the playbook to ensure that a `{{kafka_data_dir}}/offset-files` subdirectory exists (and is owned by the `{{kafka_user}}` username) and the workers are configured to place their offset files in that directory for standalone Kafka deployments.

This PR also removes a few spurious debug statements that somehow were left in a previous PR. With these changes, the `modify-connectors.yml` playbook should be much more useful to users. 