### PR TITLE
Fix default value for action_list in default configuration file

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -16,4 +16,4 @@ user: 'centos'
 # the default region to search (the us-west-2 EC2 region)
 region: us-west-2
 # define an ampty action_list as the default operation
-action_list: { }
+action_list: [ ]


### PR DESCRIPTION
The default `action_list` value defined in the default configuration file was set to an empty dictionary; it should have been set to an empty list (it's a list, not a dictionary value). This PR fixes that issue (which would appear as an error in the Ansible playbook run if the default configuration file was used, as is).